### PR TITLE
Update 'space between' functionality

### DIFF
--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -67,8 +67,8 @@
    "gap-x-" [:column-gap]
    "gap-y-" [:row-gap]
 
-   ["space-x-" "& > * + *"] [:padding-left :padding-right]
-   ["space-y-" "& > * + *"] [:padding-top :padding-bottom]
+   ["space-x-" "& > * + *"] [:margin-left]
+   ["space-y-" "& > * + *"] [:margin-top]
    })
 
 (defn generate-spacing-aliases [{:keys [spacing] :as build-state}]


### PR DESCRIPTION
As per https://tailwindcss.com/docs/space, space-x- and space-y- should inform margins, not padding.