### PR TITLE
add italic font style

### DIFF
--- a/src/main/shadow/css/aliases.edn
+++ b/src/main/shadow/css/aliases.edn
@@ -237,6 +237,10 @@
  :font-extrabold {:font-weight "800"}
  :font-black {:font-weight "900"}
 
+ ;; font style
+ :italic {:font-style "italic"}
+ :not-italic {:font-style "normal"}
+
  ;; font
  :font-sans {:font-family "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\""}
  :font-serif {:font-family "ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif"}


### PR DESCRIPTION
https://tailwindcss.com/docs/font-style

`:italic` is significantly shorter than `{:font-style "italic"}`? :)