### PR TITLE
Avoid indexing non-clj files.

### DIFF
--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -412,7 +412,7 @@
 #?(:clj
    (do (defn clj-file? [filename]
          ;; .clj .cljs .cljc .cljd
-         (str/index-of filename ".clj"))
+         (re-matches #".+\.clj[cs]?$" filename))
 
        (defn index-file [build-state ^File file]
          (let [src (slurp file)]


### PR DESCRIPTION
It might be there's a directory/file which happens to contain `.clj` (good example would be `.clj-kondo`) but isn't actually a clojure file. This narrows the search a little.