### PR TITLE
Unique class names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ pom.xml.asc
 /.idea
 .hgignore
 .hg/
+/.lsp/
+/.clj-kondo/

--- a/src/main/shadow/css.clj
+++ b/src/main/shadow/css.clj
@@ -37,7 +37,7 @@
         ;; but may end up emitting invalid references in code
         ;; which again is fine in JS since it'll just be undefined
         css-id
-        (s/generate-id ns-str line column)
+        (s/generate-id (vec body))
 
         passthrough
         (->> body

--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -187,8 +187,8 @@
       (let [all-rules
             (->> (for [ns (:chunk-namespaces chunk)
                        :let [{:keys [ns css] :as ns-info} (get namespaces ns)]
-                       {:keys [line column] :as form-info} css
-                       :let [css-id (s/generate-id ns line column)]]
+                       {:keys [form] :as form-info} css
+                       :let [css-id (s/generate-id form)]]
                    (-> (ana/process-form build-state form-info)
                        (assoc
                          :ns ns

--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -91,11 +91,15 @@
       (emitln w "  " (name prop) ": " (get group-rules prop) ";"))
     (emitln w "}")))
 
+(defn emit-meta-comment [w rules]
+  (emitln w (str "/*\n"
+                 (str/join "\n"
+                           (for [{:keys [ns line column]} rules]
+                             (str ns " " line ":" column )))
+                 "\n*/")))
+
 (defn emit-def [w {:keys [sel rules at-rules ns line column rules] :as def}]
-  ;; (emitln w (str "/* " ns " " line ":" column " */"))
-
   (emit-rule w sel rules)
-
   (doseq [[media-query rules] at-rules]
     (emitln w media-query "{")
     (emit-rule w sel rules)
@@ -114,8 +118,10 @@
               [(doseq [inc classpath-includes]
                  (emitln sw (slurp (io/resource inc))))])
 
-          (doseq [def rules]
-            (emit-def sw def))
+          (doseq [[_ def-rules] (group-by :css-id rules)]
+            (emit-meta-comment sw def-rules)
+            (emit-def sw (first def-rules)))
+
           (.toString sw))))))
 
 (defn collect-namespaces-for-chunk

--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -91,7 +91,10 @@
       (emitln w "  " (name prop) ": " (get group-rules prop) ";"))
     (emitln w "}")))
 
-(defn emit-meta-comments [w rules]
+(defn emit-meta-comments
+  "Within a single comment, output a list of namespaces, line and column numbers
+  for a given set of rules."
+  [w rules]
   (emitln w (str "/*\n"
                  (str/join "\n"
                            (for [{:keys [ns line column]} rules]

--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -91,7 +91,7 @@
       (emitln w "  " (name prop) ": " (get group-rules prop) ";"))
     (emitln w "}")))
 
-(defn emit-meta-comment [w rules]
+(defn emit-meta-comments [w rules]
   (emitln w (str "/*\n"
                  (str/join "\n"
                            (for [{:keys [ns line column]} rules]
@@ -119,7 +119,9 @@
                  (emitln sw (slurp (io/resource inc))))])
 
           (doseq [[_ def-rules] (group-by :css-id rules)]
-            (emit-meta-comment sw def-rules)
+            ;; emit comments for all of the rules
+            (emit-meta-comments sw def-rules)
+            ;; but we only need to emit the first actual def
             (emit-def sw (first def-rules)))
 
           (.toString sw))))))

--- a/src/main/shadow/css/specs.cljc
+++ b/src/main/shadow/css/specs.cljc
@@ -96,8 +96,8 @@
       conformed)))
 
 (defn generate-id
-  "Generates a class name which is unique given the contents. Please have a look
-  at the tests for more information."
+  "Generates a class name which is unique given the contents. Will account for
+  different ordering within the subqueries."
   [rules]
   (str "sc-" (postwalk
               (fn [rule]

--- a/src/main/shadow/css/specs.cljc
+++ b/src/main/shadow/css/specs.cljc
@@ -1,6 +1,7 @@
 (ns shadow.css.specs
   (:require [clojure.spec.alpha :as s]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            [clojure.walk :refer [postwalk]]))
 
 (s/def ::alias keyword?)
 
@@ -94,11 +95,21 @@
       {:parts [] :invalid true :body body :spec (s/explain-data ::class-def body)}
       conformed)))
 
-(defn generate-id [ns line column]
-  (str (-> (str ns)
-           (str/replace #"\." "_")
-           (munge))
-       "__"
-       "L" line
-       "_"
-       "C" column))
+(defn generate-id
+  "Generates a class name which is unique given the contents. Please have a look
+  at the tests for more information."
+  [rules]
+  (str "sc-" (postwalk
+              (fn [rule]
+                (cond
+                  ;; postwalk will give you a vector pair for a map before it
+                  ;; gives you the actual map
+                  (map-entry? rule)
+                  rule
+
+                  (vector? rule)
+                  (hash (sort rule))
+
+                  :else
+                  (hash rule)))
+              rules)))

--- a/src/test/shadow/css/specs_test.cljc
+++ b/src/test/shadow/css/specs_test.cljc
@@ -1,0 +1,33 @@
+(ns shadow.css.specs-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [shadow.css.specs :as specs]))
+
+(deftest generate-id-test
+  (testing "Complex ID"
+    (is (= "sc--1789522625"
+           (specs/generate-id [:px-4 :my-2
+                               "pass"
+                               :c-text-1
+                               [:&hover :py-10]
+                               [:md+ :px-6
+                                ["@media print" :px-2]]
+                               [:lg+ :px-8
+                                [:&hover :py-12]]]))))
+
+  (testing "Order of rules"
+    (testing "doesn't matter within selectors/main list"
+      (is (= (specs/generate-id [:px-4 :my-2
+                                 [:&hover :m-4 :py-10 :px-4]
+                                 [:lg+ :px-8
+                                  [:&hover :p-4 :py-12]]])
+             (specs/generate-id [:px-4 :my-2
+                                 [:&hover :py-10 :m-4 :px-4]
+                                 [:lg+ :px-8
+                                  [:&hover :py-12 :p-4]]]))))
+
+    (testing "does matter for the whole structure"
+      (is (not= (specs/generate-id [:m-4
+                                    [:&hover :px-4]])
+                (specs/generate-id [:px-4
+                                    [:&hover :m-4]]))))))


### PR DESCRIPTION
This will make class names unique according to the rules and only put them in the CSS once. To make up for losing the usefulness of having the ns line/num in the name, I've started printing them in the output which gives this sort of thing:

```css
/*
example.frontend.pages.dash 10:11
example.frontend.components.toast 17:29
example.frontend.pages.person 11:9
*/
.sc-729220566 {
  background-color: #fda4af;
}
```

My concern is the use of `hash` and just how consistent it is everywhere, however, I've tested it across different architectures and clojure versions and the output seems to be the same.