### PR TITLE
Notify on missing :shadow.css/include

### DIFF
--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -116,7 +116,11 @@
 
           #?@(:clj
               [(doseq [inc classpath-includes]
-                 (emitln sw (slurp (io/resource inc))))])
+                 (if-some [include (io/resource inc)]
+                   (emitln sw (slurp include))
+                   (.println
+                    System/err
+                    (format "[ERROR] shadow.css.build - Couldn't find :shadow.css/include %s " inc))))])
 
           (doseq [def rules]
             (emit-def sw def))

--- a/src/main/shadow/css/build.cljc
+++ b/src/main/shadow/css/build.cljc
@@ -118,9 +118,12 @@
               [(doseq [inc classpath-includes]
                  (if-some [include (io/resource inc)]
                    (emitln sw (slurp include))
-                   (.println
-                    System/err
-                    (format "[ERROR] shadow.css.build - Couldn't find :shadow.css/include %s " inc))))])
+                   (let [message (format "Couldn't find :shadow.css/include %s " inc)]
+                     (throw
+                       (ex-info
+                         message
+                         {:classpath-includes classpath-includes
+                          :include inc})))))])
 
           (doseq [def rules]
             (emit-def sw def))


### PR DESCRIPTION
Hi again,

This PR adds minor change that notifies user if some shadow.css/include is missing or not found.

Pre this change ```shadow.css.build/generate``` would fail with
```
#error {
 :cause "Cannot open <nil> as a Reader."
 :via
 [{:type java.lang.IllegalArgumentException
   :message "Cannot open <nil> as a Reader."
   :at [clojure.java.io$fn__11679 invokeStatic "io.clj" 291]}]
   .
   .
   .
   [shadow.css.build$build_css_for_chunk$fn__66425 invoke "NO_SOURCE_FILE" 119]
```

that points to location where error happened but doesn't show what missing resource caused it.

On few occasions I had problems with either typo or classpath issue and it wasn't easy to find what resource was causing it.

Hope that I'm not missing something....

Kind regards,
Robert

